### PR TITLE
Implemented the spwn file icon

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.4.0",
+	"version": "0.7.0",
     "configurations": [
         
 

--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ Basic language support for the SPWN programming language for Geometry Dash, incl
 - Added support for raw strings
 - Added support for special property names
 - Fixed some bugs
+
+### 0.7.0
+
+- Implemented the spwn file icon

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "Spu7Nix",
     "displayName": "SPWN Language Support",
     "description": "Language support for SPWN",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "icon": "spwn_logo_smol.png",
     "repository": {
         "type" : "git",
@@ -20,7 +20,11 @@
             "id": "spwn",
             "aliases": ["SPWN", "spwn"],
             "extensions": [".spwn"],
-            "configuration": "./language-configuration.json"
+            "configuration": "./language-configuration.json",
+            "icon": {
+                "dark": "./spwn_logo_smol.png",
+                "light": "./spwn_logo_smol.png"
+            }
         }],
         "grammars": [{
             "language": "spwn",


### PR DESCRIPTION
As of recently vscode supports custom file icons in language extensions, thus I decided to implement it for spwn.